### PR TITLE
FIX for Last Run Status: Malwarebytes Trial Reset Failed. Last Result: 267011

### DIFF
--- a/Malwarebytes-Premium-Reset.ps1
+++ b/Malwarebytes-Premium-Reset.ps1
@@ -2,7 +2,7 @@
 #                                                                                                      #
 # File Name: Malware-Byte-Premium-Reset.ps1     # Output: Schedule a task that resets the              #
 # Author: Ammar S.A.A                           # Malwarebytes Premium trial by changing the           #
-# Version: 1.0                                  # MachineGuid registry value                           #
+# Version: 2.6                                  # MachineGuid registry value                           #
 #                                                                                                      #
 ########################################################################################################
 #                       https://github.com/ammarsaa/Malwarebytes-Premium-Reset                         #
@@ -62,7 +62,7 @@ switch ($taskRunResult.LastTaskResult) {
         Write-Host "Last Run Status: Malwarebytes Trial Was Resetted Successfully."
     }
     267011 {
-        Write-Host "Task has been scheduled successfully."
+        Write-Host "Status: Task has never ran but exists."
     }
     default {
         Write-Host "Last Run Status: Malwarebytes Trial Reset Failed. Last Result: $($taskRunResult.LastTaskResult)"

--- a/Malwarebytes-Premium-Reset.ps1
+++ b/Malwarebytes-Premium-Reset.ps1
@@ -57,10 +57,16 @@ if ($result) {
 # Code for checking if the task was completed successfully
 $taskRunResult = Get-ScheduledTask -TaskName $taskName | Get-ScheduledTaskInfo
 
-if ($taskRunResult.LastTaskResult -eq 0) {
-    Write-Host "Last Run Status: Malwarebytes Trial Was Resetted Successfully."
-} else {
-    Write-Host "Last Run Status: Malwarebytes Trial Reset Failed. Last Result: $($taskRunResult.LastTaskResult)"
+switch ($taskRunResult.LastTaskResult) {
+    0 {
+        Write-Host "Last Run Status: Malwarebytes Trial Was Resetted Successfully."
+    }
+    267011 {
+        Write-Host "Task has been scheduled successfully."
+    }
+    default {
+        Write-Host "Last Run Status: Malwarebytes Trial Reset Failed. Last Result: $($taskRunResult.LastTaskResult)"
+    }
 }
 
 # Keeps the window open

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 > - If you get a `UnauthorizedAccess` error when attempting to run the `.ps1` file you must change your execution policy.
 > - Run `Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force` before running the `.ps1` file.
 > 
-> ![xFpsefS5rx](https://github.com/Scrut1ny/Malwarebytes-Premium-Bypass/assets/53458032/5d837082-b5aa-4662-8fa9-ca990efe6cf3)
+> ![firstRunOfScript](https://github.com/Scrut1ny/Malwarebytes-Premium-Bypass/assets/63854344/12f71499-8030-4e3d-8295-257203054eab)
 
 
 ### HOW TO:


### PR DESCRIPTION
267011 
This value means that the task has not yet run but has been created successfully and waiting to be run.